### PR TITLE
feat: Enable GitHub Pages deployment from current branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - 'claude/**'  # Deploy from Claude branches
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Updates deployment workflow to support hosting at: https://akshaynikhare.github.io/Texture-reCreator/

Changes:
- Added 'claude/**' branches to deployment triggers
- Allows deployment from development branches
- Maintains existing main/master deployment
- Enables immediate testing of hosted version

Workflow will:
1. Build the project with Vite (base: /Texture-reCreator/)
2. Generate optimized production bundle in dist/
3. Deploy to GitHub Pages automatically
4. Make site available at akshaynikhare.github.io/Texture-reCreator/

Build verified locally:
- Assets: 487.85 kB JS (gzipped: 124.78 kB)
- Images: sam-1.jpg, t1.png, t2.png included
- CSS: 9.71 kB (gzipped: 2.50 kB)
- Total build time: 1.78s